### PR TITLE
feature: add source control buttons

### DIFF
--- a/packages/memory/src/config.ts
+++ b/packages/memory/src/config.ts
@@ -3,7 +3,7 @@ import { root } from './root.ts'
 
 export const threshold = 465_000
 
-export const instantiations = 3000
+export const instantiations = 3200
 
 export const instantiationsPath = join(root, 'packages', 'source-control-worker')
 

--- a/packages/source-control-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/source-control-worker/src/parts/CommandMap/CommandMap.ts
@@ -21,6 +21,7 @@ import * as HandleMouseOut from '../HandleMouseOut/HandleMouseOut.ts'
 import * as HandleMouseOutAt from '../HandleMouseOutAt/HandleMouseOutAt.ts'
 import * as HandleMouseOver from '../HandleMouseOver/HandleMouseOver.ts'
 import * as HandleMouseOverAt from '../HandleMouseOverAt/HandleMouseOverAt.ts'
+import * as HandleSourceControlButtonClick from '../HandleSourceControlButtonClick/HandleSourceControlButtonClick.ts'
 import * as HandleWheel from '../HandleWheel/HandleWheel.ts'
 import { handleWorkspaceRefresh } from '../HandleWorkspaceRefresh/HandleWorkspaceRefresh.ts'
 import * as Initialize from '../Initialize/Initialize.ts'
@@ -65,6 +66,7 @@ export const commandMap = {
   'SourceControl.handleMouseOutAt': WrapCommand.wrapCommand(HandleMouseOutAt.handleMouseOutAt),
   'SourceControl.handleMouseOver': WrapCommand.wrapCommand(HandleMouseOver.handleMouseOver),
   'SourceControl.handleMouseOverAt': WrapCommand.wrapCommand(HandleMouseOverAt.handleMouseOverAt),
+  'SourceControl.handleSourceControlButtonClick': WrapCommand.wrapCommand(HandleSourceControlButtonClick.handleSourceControlButtonClick),
   'SourceControl.handleWheel': WrapCommand.wrapCommand(HandleWheel.handleWheel),
   'SourceControl.handleWorkspaceRefresh': WrapCommand.wrapCommand(handleWorkspaceRefresh),
   'SourceControl.loadContent': WrapCommand.wrapCommand(LoadContent.loadContent),

--- a/packages/source-control-worker/src/parts/CreateDefaultState/CreateDefaultState.ts
+++ b/packages/source-control-worker/src/parts/CreateDefaultState/CreateDefaultState.ts
@@ -47,6 +47,7 @@ export const createDefaultState = (): SourceControlState => ({
   scrollBarActive: false,
   scrollBarHeight: 0,
   showGenerateCommitMessageButton: false,
+  sourceControlButtons: [],
   splitButtonEnabled: false,
   untracked: [],
   viewMode: 1,

--- a/packages/source-control-worker/src/parts/DiffItems/DiffItems.ts
+++ b/packages/source-control-worker/src/parts/DiffItems/DiffItems.ts
@@ -7,6 +7,7 @@ export const isEqual = (oldState: SourceControlState, newState: SourceControlSta
     oldState.items === newState.items &&
     oldState.maxLineY === newState.maxLineY &&
     oldState.minLineY === newState.minLineY &&
+    oldState.sourceControlButtons === newState.sourceControlButtons &&
     oldState.visibleItems === newState.visibleItems
   )
 }

--- a/packages/source-control-worker/src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts
+++ b/packages/source-control-worker/src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts
@@ -8,3 +8,4 @@ export const HandleMouseOver = 7
 export const HandleMouseOverAt = 8
 export const HandleWheel = 9
 export const HandleClickAction = 10
+export const HandleClickSourceControlButton = 11

--- a/packages/source-control-worker/src/parts/GetHeaderHeight/GetHeaderHeight.ts
+++ b/packages/source-control-worker/src/parts/GetHeaderHeight/GetHeaderHeight.ts
@@ -1,0 +1,8 @@
+import type { ActionButton } from '../ActionButton/ActionButton.ts'
+
+const inputPaddingBlock = 11
+const buttonBlockHeight = 34
+
+export const getHeaderHeight = (inputBoxHeight: number, sourceControlButtons: readonly ActionButton[]): number => {
+  return inputBoxHeight + inputPaddingBlock + sourceControlButtons.length * buttonBlockHeight
+}

--- a/packages/source-control-worker/src/parts/GetSourceControlButtonVirtualDom/GetSourceControlButtonVirtualDom.ts
+++ b/packages/source-control-worker/src/parts/GetSourceControlButtonVirtualDom/GetSourceControlButtonVirtualDom.ts
@@ -1,0 +1,27 @@
+import type { VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
+import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
+import type { ActionButton } from '../ActionButton/ActionButton.ts'
+import * as ClassNames from '../ClassNames/ClassNames.ts'
+import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.ts'
+import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
+
+export const getSourceControlButtonVirtualDom = (button: ActionButton): readonly VirtualDomNode[] => {
+  const { id, label } = button
+  return [
+    {
+      childCount: 1,
+      className: ClassNames.SplitButton,
+      type: VirtualDomElements.Div,
+    },
+    {
+      childCount: 1,
+      className: ClassNames.SplitButtonContent,
+      name: label,
+      onClick: DomEventListenerFunctions.HandleClickSourceControlButton,
+      tabIndex: 0,
+      title: id,
+      type: VirtualDomElements.Div,
+    },
+    text(label),
+  ]
+}

--- a/packages/source-control-worker/src/parts/GetSourceControlButtonsVirtualDom/GetSourceControlButtonsVirtualDom.ts
+++ b/packages/source-control-worker/src/parts/GetSourceControlButtonsVirtualDom/GetSourceControlButtonsVirtualDom.ts
@@ -1,0 +1,7 @@
+import type { VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
+import type { ActionButton } from '../ActionButton/ActionButton.ts'
+import * as GetSourceControlButtonVirtualDom from '../GetSourceControlButtonVirtualDom/GetSourceControlButtonVirtualDom.ts'
+
+export const getSourceControlButtonsVirtualDom = (buttons: readonly ActionButton[]): readonly VirtualDomNode[] => {
+  return buttons.flatMap(GetSourceControlButtonVirtualDom.getSourceControlButtonVirtualDom)
+}

--- a/packages/source-control-worker/src/parts/GetSourceControlVirtualDom/GetSourceControlVirtualDom.ts
+++ b/packages/source-control-worker/src/parts/GetSourceControlVirtualDom/GetSourceControlVirtualDom.ts
@@ -1,25 +1,25 @@
 import type { VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
 import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
+import type { ActionButton } from '../ActionButton/ActionButton.ts'
 import type { VisibleItem } from '../VisibleItem/VisibleItem.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.ts'
+import * as GetSourceControlButtonsVirtualDom from '../GetSourceControlButtonsVirtualDom/GetSourceControlButtonsVirtualDom.ts'
 import * as GetSourceControlHeaderVirtualDom from '../GetSourceControlHeaderVirtualDom/GetSourceControlHeaderVirtualDom.ts'
 import * as GetSourceControlListVirtualDom from '../GetSourceControlListVirtualDom/GetSourceControlListVirtualDom.ts'
-import * as GetSplitButtonVirtualDom from '../GetSplitButtonVirtualDom/GetSplitButtonVirtualDom.ts'
 import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 
 const className = MergeClassNames.mergeClassNames(ClassNames.Viewlet, ClassNames.SourceControl)
 
 export const getSourceControlVirtualDom = (
   items: readonly VisibleItem[],
-  splitButtonEnabled: boolean,
+  sourceControlButtons: readonly ActionButton[],
   inputPlaceholder: string,
   inputMessage: string,
 ): readonly VirtualDomNode[] => {
-  const hasItems = items.length > 0
   const dom = [
     {
-      childCount: splitButtonEnabled ? 3 : 2,
+      childCount: 2 + sourceControlButtons.length,
       className: className,
       onContextMenu: DomEventListenerFunctions.HandleContextMenu,
       onMouseOver: DomEventListenerFunctions.HandleMouseOver,
@@ -29,7 +29,7 @@ export const getSourceControlVirtualDom = (
       type: VirtualDomElements.Div,
     },
     ...GetSourceControlHeaderVirtualDom.getSourceControlHeaderVirtualDom(inputPlaceholder, inputMessage),
-    ...GetSplitButtonVirtualDom.getSplitButtonVirtualDom(hasItems, splitButtonEnabled, 'Commit'),
+    ...GetSourceControlButtonsVirtualDom.getSourceControlButtonsVirtualDom(sourceControlButtons),
     ...GetSourceControlListVirtualDom.getSourceControlListVirtualDom(items),
   ]
   return dom

--- a/packages/source-control-worker/src/parts/HandleSourceControlButtonClick/HandleSourceControlButtonClick.ts
+++ b/packages/source-control-worker/src/parts/HandleSourceControlButtonClick/HandleSourceControlButtonClick.ts
@@ -1,0 +1,19 @@
+import type { SourceControlState } from '../SourceControlState/SourceControlState.ts'
+import * as ExtensionHostCommand from '../ExtensionHostCommand/ExtensionHostCommand.ts'
+import { loadContent } from '../LoadContent/LoadContent.ts'
+import * as Logger from '../Logger/Logger.ts'
+
+export const handleSourceControlButtonClick = async (state: SourceControlState, name: string): Promise<SourceControlState> => {
+  const button = state.sourceControlButtons.find((button) => button.label === name)
+  if (!button) {
+    Logger.warn(`[source-control-worker] Source control button not found ${name}`)
+    return state
+  }
+  await ExtensionHostCommand.executeCommand(button.command, state.assetDir, state.platform, state.inputValue)
+  const newState = await loadContent(state, {})
+  return {
+    ...newState,
+    inputMessage: '',
+    inputValue: '',
+  }
+}

--- a/packages/source-control-worker/src/parts/LoadContent/LoadContent.ts
+++ b/packages/source-control-worker/src/parts/LoadContent/LoadContent.ts
@@ -4,6 +4,7 @@ import { getDisplayItems } from '../GetDisplayItems/GetDisplayItems.ts'
 import * as GetFileIcons from '../GetFileIcons/GetFileIcons.ts'
 import * as GetFinalDeltaY from '../GetFinalDeltaY/GetFinalDeltaY.ts'
 import { getGroups } from '../GetGroups/GetGroups.ts'
+import { getHeaderHeight } from '../GetHeaderHeight/GetHeaderHeight.ts'
 import { getInputHeight } from '../GetInputHeight/GetInputHeight.ts'
 import { getListHeight } from '../GetListHeight/GetListHeight.ts'
 import * as GetNumberOfVisibleItems from '../GetNumberOfVisibleItems/GetNumberOfVisibleItems.ts'
@@ -11,6 +12,7 @@ import * as GetProtocol from '../GetProtocol/GetProtocol.ts'
 import { getVisibleSourceControlItems } from '../GetVisibleSourceControlItems/GetVisibleSourceControlItems.ts'
 import * as Preferences from '../Preferences/Preferences.ts'
 import { requestSourceActions } from '../RequestSourceActions/RequestSourceActions.ts'
+import { requestSourceControlButtons } from '../RequestSourceControlButtons/RequestSourceControlButtons.ts'
 import { restoreExpandedGroups } from '../RestoreExpandedGroups/RestoreExpandedGroups.ts'
 import { restoreState } from '../RestoreState/RestoreState.ts'
 import * as ScrollBarFunctions from '../ScrollBarFunctions/ScrollBarFunctions.ts'
@@ -47,6 +49,7 @@ export const loadContent = async (state: SourceControlState, savedState: unknown
   const displayItems = getDisplayItems(allGroups, expandedGroups, iconDefinitions)
 
   const actionsCache = await requestSourceActions()
+  const sourceControlButtons = await requestSourceControlButtons()
 
   // TODO make preferences async and more functional
   const splitButtonEnabled = await Preferences.get('sourceControl.splitButtonEnabled')
@@ -63,6 +66,7 @@ export const loadContent = async (state: SourceControlState, savedState: unknown
   const finalDeltaY = GetFinalDeltaY.getFinalDeltaY(listHeight, itemHeight, total)
   const inputPlaceholder = SourceControlStrings.messageEnterToCommitOnMaster()
   const inputBoxHeight = await getInputHeight(inputValue, width, inputFontFamily, inputFontSize, inputFontWeight, inputLetterSpacing, inputLineHeight, inputPadding)
+  const headerHeight = getHeaderHeight(inputBoxHeight, sourceControlButtons)
   return {
     ...state,
     actionsCache,
@@ -73,6 +77,7 @@ export const loadContent = async (state: SourceControlState, savedState: unknown
     fileIconCache: newFileIconCache,
     finalDeltaY,
     gitRoot,
+    headerHeight,
     iconDefinitions,
     initial: false,
     inputBoxHeight,
@@ -83,6 +88,7 @@ export const loadContent = async (state: SourceControlState, savedState: unknown
     root,
     scrollBarHeight,
     showGenerateCommitMessageButton,
+    sourceControlButtons,
     splitButtonEnabled,
     visibleItems,
   }

--- a/packages/source-control-worker/src/parts/RenderEventListeners/RenderEventListeners.ts
+++ b/packages/source-control-worker/src/parts/RenderEventListeners/RenderEventListeners.ts
@@ -47,5 +47,9 @@ export const renderEventListeners = (): readonly DomEventListener[] => {
       name: DomEventListenersFunctions.HandleClickAction,
       params: ['handleActionClick', EventExpression.TargetName],
     },
+    {
+      name: DomEventListenersFunctions.HandleClickSourceControlButton,
+      params: ['handleSourceControlButtonClick', EventExpression.TargetName],
+    },
   ]
 }

--- a/packages/source-control-worker/src/parts/RenderItems/RenderItems.ts
+++ b/packages/source-control-worker/src/parts/RenderItems/RenderItems.ts
@@ -3,10 +3,10 @@ import type { SourceControlState } from '../SourceControlState/SourceControlStat
 import * as GetSourceControlDom from '../GetSourceControlVirtualDom/GetSourceControlVirtualDom.ts'
 
 export const renderItems = (oldState: SourceControlState, newState: SourceControlState): any => {
-  const { id, initial, inputMessage, inputPlaceholder, splitButtonEnabled, visibleItems } = newState
+  const { id, initial, inputMessage, inputPlaceholder, sourceControlButtons, visibleItems } = newState
   if (initial) {
     return [ViewletCommand.SetDom2, id, []]
   }
-  const dom = GetSourceControlDom.getSourceControlVirtualDom(visibleItems, splitButtonEnabled, inputPlaceholder, inputMessage)
+  const dom = GetSourceControlDom.getSourceControlVirtualDom(visibleItems, sourceControlButtons, inputPlaceholder, inputMessage)
   return [ViewletCommand.SetDom2, id, dom]
 }

--- a/packages/source-control-worker/src/parts/RequestSourceControlButtons/RequestSourceControlButtons.ts
+++ b/packages/source-control-worker/src/parts/RequestSourceControlButtons/RequestSourceControlButtons.ts
@@ -1,0 +1,14 @@
+import type { ActionButton } from '../ActionButton/ActionButton.ts'
+import * as ExtensionMeta from '../ExtensionMeta/ExtensionMeta.ts'
+
+export const requestSourceControlButtons = async (): Promise<readonly ActionButton[]> => {
+  const extensions = await ExtensionMeta.getExtensions()
+  const buttons: ActionButton[] = []
+  for (const extension of extensions) {
+    if (!extension || !Array.isArray(extension['source-control-buttons'])) {
+      continue
+    }
+    buttons.push(...extension['source-control-buttons'])
+  }
+  return buttons
+}

--- a/packages/source-control-worker/src/parts/SourceControlState/SourceControlState.ts
+++ b/packages/source-control-worker/src/parts/SourceControlState/SourceControlState.ts
@@ -1,3 +1,4 @@
+import type { ActionButton } from '../ActionButton/ActionButton.ts'
 import type { ActionsCache } from '../ActionsCache/ActionsCache.ts'
 import type { DisplayItem } from '../DisplayItem/DisplayItem.ts'
 import type { FileIconCache } from '../FileIconCache/FileIconCache.ts'
@@ -52,6 +53,7 @@ export interface SourceControlState {
   readonly scrollBarActive: boolean
   readonly scrollBarHeight: number
   readonly showGenerateCommitMessageButton: boolean
+  readonly sourceControlButtons: readonly ActionButton[]
   readonly splitButtonEnabled: boolean
   readonly untracked: readonly any[]
   readonly viewMode: ViewMode

--- a/packages/source-control-worker/test/GetSourceControlButtonVirtualDom.test.ts
+++ b/packages/source-control-worker/test/GetSourceControlButtonVirtualDom.test.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@jest/globals'
+import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
+import * as ClassNames from '../src/parts/ClassNames/ClassNames.ts'
+import * as DomEventListenerFunctions from '../src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts'
+import { getSourceControlButtonVirtualDom } from '../src/parts/GetSourceControlButtonVirtualDom/GetSourceControlButtonVirtualDom.ts'
+
+test('getSourceControlButtonVirtualDom', () => {
+  const result = getSourceControlButtonVirtualDom({
+    command: 'git.commitAndSync',
+    icon: 'Check',
+    id: 'git.commitAndSync',
+    label: 'Commit & Sync',
+  })
+
+  expect(result).toEqual([
+    {
+      childCount: 1,
+      className: ClassNames.SplitButton,
+      type: VirtualDomElements.Div,
+    },
+    {
+      childCount: 1,
+      className: ClassNames.SplitButtonContent,
+      name: 'Commit & Sync',
+      onClick: DomEventListenerFunctions.HandleClickSourceControlButton,
+      tabIndex: 0,
+      title: 'git.commitAndSync',
+      type: VirtualDomElements.Div,
+    },
+    {
+      childCount: 0,
+      text: 'Commit & Sync',
+      type: VirtualDomElements.Text,
+    },
+  ])
+})

--- a/packages/source-control-worker/test/HandleSourceControlButtonClick.test.ts
+++ b/packages/source-control-worker/test/HandleSourceControlButtonClick.test.ts
@@ -1,0 +1,54 @@
+import { expect, jest, test } from '@jest/globals'
+import { ExtensionHost } from '@lvce-editor/rpc-registry'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import { handleSourceControlButtonClick } from '../src/parts/HandleSourceControlButtonClick/HandleSourceControlButtonClick.ts'
+
+test('handleSourceControlButtonClick', async () => {
+  const commandMap = {
+    'ExtensionHostCommand.executeCommand': async (): Promise<void> => {},
+    'ExtensionHostManagement.activateByEvent': async (): Promise<void> => {},
+    'ExtensionHostSourceControl.getEnabledProviderIds': async (): Promise<readonly string[]> => [],
+    'Extensions.getExtensions': async (): Promise<readonly any[]> => [],
+    'IconTheme.getIcons': async (): Promise<readonly string[]> => [],
+    'MeasureTextHeight.measureTextBlockHeight': async (): Promise<number> => 30,
+    'Preferences.get': async (): Promise<any> => false,
+  }
+  using extensionHostMockRpc = ExtensionHost.registerMockRpc(commandMap)
+  using mockRpc = RendererWorker.registerMockRpc(commandMap)
+
+  const state = {
+    ...createDefaultState(),
+    inputValue: 'test message',
+    sourceControlButtons: [
+      {
+        command: 'git.commitAndSync',
+        icon: 'Check',
+        id: 'git.commitAndSync',
+        label: 'Commit & Sync',
+      },
+    ],
+  }
+
+  const result = await handleSourceControlButtonClick(state, 'Commit & Sync')
+
+  expect(extensionHostMockRpc.invocations).toContainEqual(['ExtensionHostCommand.executeCommand', 'git.commitAndSync', 'test message'])
+  expect(result.inputValue).toBe('')
+  expect(mockRpc.invocations).toEqual([
+    ['ExtensionHostManagement.activateByEvent', 'onCommand:git.commitAndSync', '', 0],
+    ['ExtensionHostManagement.activateByEvent', 'onSourceControl:file', '', 0],
+    ['Preferences.get', 'sourceControl.splitButtonEnabled'],
+    ['IconTheme.getIcons', []],
+  ])
+})
+
+test('handleSourceControlButtonClick - unknown button', async () => {
+  const consoleWarnSpy = jest.spyOn((globalThis as any).console, 'warn').mockImplementation(() => {})
+  const state = createDefaultState()
+
+  const result = await handleSourceControlButtonClick(state, 'Missing')
+
+  expect(result).toBe(state)
+  expect(consoleWarnSpy).toHaveBeenCalledWith('[source-control-worker] Source control button not found Missing')
+  consoleWarnSpy.mockRestore()
+})

--- a/packages/source-control-worker/test/LoadContent.test.ts
+++ b/packages/source-control-worker/test/LoadContent.test.ts
@@ -127,6 +127,14 @@ test('loadContent - with source control actions', async (): Promise<void> => {
         action1: 'value1',
         action2: 'value2',
       },
+      'source-control-buttons': [
+        {
+          command: 'git.commitAndSync',
+          icon: 'Check',
+          id: 'git.commitAndSync',
+          label: 'Commit & Sync',
+        },
+      ],
     },
   ]
 
@@ -148,6 +156,15 @@ test('loadContent - with source control actions', async (): Promise<void> => {
     action1: 'value1',
     action2: 'value2',
   })
+  expect(result.sourceControlButtons).toEqual([
+    {
+      command: 'git.commitAndSync',
+      icon: 'Check',
+      id: 'git.commitAndSync',
+      label: 'Commit & Sync',
+    },
+  ])
+  expect(result.headerHeight).toBe(result.inputBoxHeight + 11 + 34)
 })
 
 test('loadContent - calculates scroll bar and visible items correctly', async (): Promise<void> => {

--- a/packages/source-control-worker/test/RequestSourceControlButtons.test.ts
+++ b/packages/source-control-worker/test/RequestSourceControlButtons.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@jest/globals'
+import { ExtensionHost } from '@lvce-editor/rpc-registry'
+import { requestSourceControlButtons } from '../src/parts/RequestSourceControlButtons/RequestSourceControlButtons.ts'
+
+test('requestSourceControlButtons', async () => {
+  const mockExtensions = [
+    {
+      'source-control-buttons': [
+        {
+          command: 'git.commitAndSync',
+          icon: 'Check',
+          id: 'git.commitAndSync',
+          label: 'Commit & Sync',
+        },
+      ],
+    },
+    {
+      'source-control-buttons': [
+        {
+          command: 'test.command',
+          icon: 'Check',
+          id: 'test.command',
+          label: 'Test',
+        },
+      ],
+    },
+  ]
+  const commandMap = {
+    'Extensions.getExtensions': async (): Promise<typeof mockExtensions> => mockExtensions,
+  }
+  using mockRpc = ExtensionHost.registerMockRpc(commandMap)
+
+  const result = await requestSourceControlButtons()
+
+  expect(result).toEqual([
+    {
+      command: 'git.commitAndSync',
+      icon: 'Check',
+      id: 'git.commitAndSync',
+      label: 'Commit & Sync',
+    },
+    {
+      command: 'test.command',
+      icon: 'Check',
+      id: 'test.command',
+      label: 'Test',
+    },
+  ])
+  expect(mockRpc.invocations).toEqual([['Extensions.getExtensions']])
+})


### PR DESCRIPTION
Adds extension-contributed source control buttons and renders them in the source control view. Button clicks execute the contributed command with the current input value and refresh the view.