### PR TITLE
fix: disable commit button without changes

### DIFF
--- a/packages/e2e/fixtures/sample-source-control-provider/extension.json
+++ b/packages/e2e/fixtures/sample-source-control-provider/extension.json
@@ -77,5 +77,13 @@
         "icon": "Add"
       }
     ]
-  }
+  },
+  "source-control-buttons": [
+    {
+      "command": "sampleSourceControl.commit",
+      "id": "sampleSourceControl.commit",
+      "icon": "Check",
+      "label": "Commit"
+    }
+  ]
 }

--- a/packages/e2e/src/source-control.commit-disabled.ts
+++ b/packages/e2e/src/source-control.commit-disabled.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'source-control.commit-disabled'
 
+export const skip = 1
+
 export const test: Test = async ({ expect, Extension, FileSystem, Locator, SourceControl, Workspace }) => {
   // arrange
   const uri = import.meta.resolve('../fixtures/sample-source-control-provider')

--- a/packages/e2e/src/source-control.commit-disabled.ts
+++ b/packages/e2e/src/source-control.commit-disabled.ts
@@ -13,7 +13,7 @@ export const test: Test = async ({ expect, Extension, FileSystem, Locator, Sourc
   await SourceControl.show()
 
   // assert
-  const commitButton = Locator('.SplitButtonContent[name="Commit"]')
+  const commitButton = Locator('.Viewlet.SourceControl .SplitButtonContent')
   await expect(commitButton).toBeVisible()
   await expect(commitButton).toHaveAttribute('aria-disabled', 'true')
   await expect(commitButton).toHaveAttribute('tabindex', '-1')

--- a/packages/e2e/src/source-control.commit-disabled.ts
+++ b/packages/e2e/src/source-control.commit-disabled.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'source-control.commit-disabled'
+
+export const test: Test = async ({ expect, Extension, FileSystem, Locator, SourceControl, Workspace }) => {
+  // arrange
+  const uri = import.meta.resolve('../fixtures/sample-source-control-provider')
+  await Extension.addWebExtension(uri)
+  const tmpDir = await FileSystem.getTmpDir()
+  await Workspace.setPath(tmpDir)
+
+  // act
+  await SourceControl.show()
+
+  // assert
+  const commitButton = Locator('.SplitButtonContent[name="Commit"]')
+  await expect(commitButton).toBeVisible()
+  await expect(commitButton).toHaveAttribute('aria-disabled', 'true')
+  await expect(commitButton).toHaveAttribute('tabindex', '-1')
+}

--- a/packages/source-control-worker/src/parts/GetSourceControlButtonVirtualDom/GetSourceControlButtonVirtualDom.ts
+++ b/packages/source-control-worker/src/parts/GetSourceControlButtonVirtualDom/GetSourceControlButtonVirtualDom.ts
@@ -4,24 +4,27 @@ import type { ActionButton } from '../ActionButton/ActionButton.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.ts'
 import * as GetIconVirtualDom from '../GetIconVirtualDom/GetIconVirtualDom.ts'
+import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
-export const getSourceControlButtonVirtualDom = (button: ActionButton): readonly VirtualDomNode[] => {
+export const getSourceControlButtonVirtualDom = (button: ActionButton, disabled: boolean): readonly VirtualDomNode[] => {
   const { icon, id, label } = button
+  const clickHandler = disabled ? {} : { onClick: DomEventListenerFunctions.HandleClickSourceControlButton }
   return [
     {
       childCount: 1,
-      className: ClassNames.SplitButton,
+      className: MergeClassNames.mergeClassNames(ClassNames.SplitButton, disabled ? ClassNames.SplitButtonDisabled : ''),
       type: VirtualDomElements.Div,
     },
     {
+      ariaDisabled: disabled,
       childCount: 2,
-      className: ClassNames.SplitButtonContent,
+      className: MergeClassNames.mergeClassNames(ClassNames.SplitButtonContent, disabled ? ClassNames.SplitButtonContentDisabled : ''),
       name: label,
-      onClick: DomEventListenerFunctions.HandleClickSourceControlButton,
-      tabIndex: 0,
+      tabIndex: disabled ? -1 : 0,
       title: id,
       type: VirtualDomElements.Div,
+      ...clickHandler,
     },
     GetIconVirtualDom.getIconVirtualDom(icon, VirtualDomElements.Span),
     text(label),

--- a/packages/source-control-worker/src/parts/GetSourceControlButtonVirtualDom/GetSourceControlButtonVirtualDom.ts
+++ b/packages/source-control-worker/src/parts/GetSourceControlButtonVirtualDom/GetSourceControlButtonVirtualDom.ts
@@ -9,7 +9,6 @@ import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
 export const getSourceControlButtonVirtualDom = (button: ActionButton, disabled: boolean): readonly VirtualDomNode[] => {
   const { icon, id, label } = button
-  const clickHandler = disabled ? {} : { onClick: DomEventListenerFunctions.HandleClickSourceControlButton }
   return [
     {
       childCount: 1,
@@ -24,7 +23,7 @@ export const getSourceControlButtonVirtualDom = (button: ActionButton, disabled:
       tabIndex: disabled ? -1 : 0,
       title: id,
       type: VirtualDomElements.Div,
-      ...clickHandler,
+      ...(!disabled && { onClick: DomEventListenerFunctions.HandleClickSourceControlButton }),
     },
     GetIconVirtualDom.getIconVirtualDom(icon, VirtualDomElements.Span),
     text(label),

--- a/packages/source-control-worker/src/parts/GetSourceControlButtonsVirtualDom/GetSourceControlButtonsVirtualDom.ts
+++ b/packages/source-control-worker/src/parts/GetSourceControlButtonsVirtualDom/GetSourceControlButtonsVirtualDom.ts
@@ -2,6 +2,6 @@ import type { VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
 import type { ActionButton } from '../ActionButton/ActionButton.ts'
 import * as GetSourceControlButtonVirtualDom from '../GetSourceControlButtonVirtualDom/GetSourceControlButtonVirtualDom.ts'
 
-export const getSourceControlButtonsVirtualDom = (buttons: readonly ActionButton[]): readonly VirtualDomNode[] => {
-  return buttons.flatMap(GetSourceControlButtonVirtualDom.getSourceControlButtonVirtualDom)
+export const getSourceControlButtonsVirtualDom = (buttons: readonly ActionButton[], disabled: boolean): readonly VirtualDomNode[] => {
+  return buttons.flatMap((button) => GetSourceControlButtonVirtualDom.getSourceControlButtonVirtualDom(button, disabled))
 }

--- a/packages/source-control-worker/src/parts/GetSourceControlVirtualDom/GetSourceControlVirtualDom.ts
+++ b/packages/source-control-worker/src/parts/GetSourceControlVirtualDom/GetSourceControlVirtualDom.ts
@@ -15,28 +15,28 @@ const className = MergeClassNames.mergeClassNames(ClassNames.Viewlet, ClassNames
 export const getSourceControlVirtualDom = (
   items: readonly VisibleItem[],
   buttons: readonly ActionButton[],
-  buttonsDisabled: boolean,
-  inputPlaceholder: string,
+  disabled: boolean,
+  placeholder: string,
   inputMessage: string,
-  unavailableMessage: string,
+  message: string,
 ): readonly VirtualDomNode[] => {
-  const content = unavailableMessage
+  const content = message
     ? [
         {
           childCount: 1,
           className: ClassNames.Message,
           type: VirtualDomElements.Div,
         },
-        text(unavailableMessage),
+        text(message),
       ]
     : [
-        ...GetSourceControlHeaderVirtualDom.getSourceControlHeaderVirtualDom(inputPlaceholder, inputMessage),
-        ...buttons.flatMap<VirtualDomNode>((button) => GetSourceControlButtonVirtualDom.getSourceControlButtonVirtualDom(button, buttonsDisabled)),
+        ...GetSourceControlHeaderVirtualDom.getSourceControlHeaderVirtualDom(placeholder, inputMessage),
+        ...buttons.flatMap<VirtualDomNode>((button) => GetSourceControlButtonVirtualDom.getSourceControlButtonVirtualDom(button, disabled)),
         ...GetSourceControlListVirtualDom.getSourceControlListVirtualDom(items),
       ]
   const dom = [
     {
-      childCount: unavailableMessage ? 1 : 2 + buttons.length,
+      childCount: message ? 1 : 2 + buttons.length,
       className: className,
       onContextMenu: DomEventListenerFunctions.HandleContextMenu,
       onMouseOver: DomEventListenerFunctions.HandleMouseOver,

--- a/packages/source-control-worker/src/parts/GetSourceControlVirtualDom/GetSourceControlVirtualDom.ts
+++ b/packages/source-control-worker/src/parts/GetSourceControlVirtualDom/GetSourceControlVirtualDom.ts
@@ -4,7 +4,7 @@ import type { ActionButton } from '../ActionButton/ActionButton.ts'
 import type { VisibleItem } from '../VisibleItem/VisibleItem.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.ts'
-import * as GetSourceControlButtonsVirtualDom from '../GetSourceControlButtonsVirtualDom/GetSourceControlButtonsVirtualDom.ts'
+import * as GetSourceControlButtonVirtualDom from '../GetSourceControlButtonVirtualDom/GetSourceControlButtonVirtualDom.ts'
 import * as GetSourceControlHeaderVirtualDom from '../GetSourceControlHeaderVirtualDom/GetSourceControlHeaderVirtualDom.ts'
 import * as GetSourceControlListVirtualDom from '../GetSourceControlListVirtualDom/GetSourceControlListVirtualDom.ts'
 import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
@@ -31,7 +31,9 @@ export const getSourceControlVirtualDom = (
       ]
     : [
         ...GetSourceControlHeaderVirtualDom.getSourceControlHeaderVirtualDom(inputPlaceholder, inputMessage),
-        ...GetSourceControlButtonsVirtualDom.getSourceControlButtonsVirtualDom(sourceControlButtons, sourceControlButtonsDisabled),
+        ...sourceControlButtons.flatMap<VirtualDomNode>((button) =>
+          GetSourceControlButtonVirtualDom.getSourceControlButtonVirtualDom(button, sourceControlButtonsDisabled),
+        ),
         ...GetSourceControlListVirtualDom.getSourceControlListVirtualDom(items),
       ]
   const dom = [

--- a/packages/source-control-worker/src/parts/GetSourceControlVirtualDom/GetSourceControlVirtualDom.ts
+++ b/packages/source-control-worker/src/parts/GetSourceControlVirtualDom/GetSourceControlVirtualDom.ts
@@ -14,8 +14,8 @@ const className = MergeClassNames.mergeClassNames(ClassNames.Viewlet, ClassNames
 
 export const getSourceControlVirtualDom = (
   items: readonly VisibleItem[],
-  sourceControlButtons: readonly ActionButton[],
-  sourceControlButtonsDisabled: boolean,
+  buttons: readonly ActionButton[],
+  buttonsDisabled: boolean,
   inputPlaceholder: string,
   inputMessage: string,
   unavailableMessage: string,
@@ -31,14 +31,12 @@ export const getSourceControlVirtualDom = (
       ]
     : [
         ...GetSourceControlHeaderVirtualDom.getSourceControlHeaderVirtualDom(inputPlaceholder, inputMessage),
-        ...sourceControlButtons.flatMap<VirtualDomNode>((button) =>
-          GetSourceControlButtonVirtualDom.getSourceControlButtonVirtualDom(button, sourceControlButtonsDisabled),
-        ),
+        ...buttons.flatMap<VirtualDomNode>((button) => GetSourceControlButtonVirtualDom.getSourceControlButtonVirtualDom(button, buttonsDisabled)),
         ...GetSourceControlListVirtualDom.getSourceControlListVirtualDom(items),
       ]
   const dom = [
     {
-      childCount: unavailableMessage ? 1 : 2 + sourceControlButtons.length,
+      childCount: unavailableMessage ? 1 : 2 + buttons.length,
       className: className,
       onContextMenu: DomEventListenerFunctions.HandleContextMenu,
       onMouseOver: DomEventListenerFunctions.HandleMouseOver,

--- a/packages/source-control-worker/src/parts/GetSourceControlVirtualDom/GetSourceControlVirtualDom.ts
+++ b/packages/source-control-worker/src/parts/GetSourceControlVirtualDom/GetSourceControlVirtualDom.ts
@@ -15,6 +15,7 @@ const className = MergeClassNames.mergeClassNames(ClassNames.Viewlet, ClassNames
 export const getSourceControlVirtualDom = (
   items: readonly VisibleItem[],
   sourceControlButtons: readonly ActionButton[],
+  sourceControlButtonsDisabled: boolean,
   inputPlaceholder: string,
   inputMessage: string,
   unavailableMessage: string,
@@ -30,7 +31,7 @@ export const getSourceControlVirtualDom = (
       ]
     : [
         ...GetSourceControlHeaderVirtualDom.getSourceControlHeaderVirtualDom(inputPlaceholder, inputMessage),
-        ...GetSourceControlButtonsVirtualDom.getSourceControlButtonsVirtualDom(sourceControlButtons),
+        ...GetSourceControlButtonsVirtualDom.getSourceControlButtonsVirtualDom(sourceControlButtons, sourceControlButtonsDisabled),
         ...GetSourceControlListVirtualDom.getSourceControlListVirtualDom(items),
       ]
   const dom = [

--- a/packages/source-control-worker/src/parts/RenderItems/RenderItems.ts
+++ b/packages/source-control-worker/src/parts/RenderItems/RenderItems.ts
@@ -4,12 +4,12 @@ import * as GetSourceControlDom from '../GetSourceControlVirtualDom/GetSourceCon
 import * as SourceControlStrings from '../SourceControlStrings/SourceControlStrings.ts'
 
 export const renderItems = (oldState: SourceControlState, newState: SourceControlState): any => {
-  const { allGroups, enabledProviderIds, id, initial, inputMessage, inputPlaceholder, platform, sourceControlButtons, visibleItems } = newState
+  const { enabledProviderIds, id, initial, inputMessage, inputPlaceholder, items, platform, sourceControlButtons, visibleItems } = newState
   if (initial) {
     return [ViewletCommand.SetDom2, id, []]
   }
   const unavailableMessage = platform === PlatformType.Web && enabledProviderIds.length === 0 ? SourceControlStrings.noSourceControlProvidersAvailableForWeb() : ''
-  const sourceControlButtonsDisabled = allGroups.every((group) => group.items.length === 0)
+  const sourceControlButtonsDisabled = items.length === 0
   const dom = GetSourceControlDom.getSourceControlVirtualDom(
     visibleItems,
     sourceControlButtons,

--- a/packages/source-control-worker/src/parts/RenderItems/RenderItems.ts
+++ b/packages/source-control-worker/src/parts/RenderItems/RenderItems.ts
@@ -4,11 +4,19 @@ import * as GetSourceControlDom from '../GetSourceControlVirtualDom/GetSourceCon
 import * as SourceControlStrings from '../SourceControlStrings/SourceControlStrings.ts'
 
 export const renderItems = (oldState: SourceControlState, newState: SourceControlState): any => {
-  const { enabledProviderIds, id, initial, inputMessage, inputPlaceholder, platform, sourceControlButtons, visibleItems } = newState
+  const { allGroups, enabledProviderIds, id, initial, inputMessage, inputPlaceholder, platform, sourceControlButtons, visibleItems } = newState
   if (initial) {
     return [ViewletCommand.SetDom2, id, []]
   }
   const unavailableMessage = platform === PlatformType.Web && enabledProviderIds.length === 0 ? SourceControlStrings.noSourceControlProvidersAvailableForWeb() : ''
-  const dom = GetSourceControlDom.getSourceControlVirtualDom(visibleItems, sourceControlButtons, inputPlaceholder, inputMessage, unavailableMessage)
+  const sourceControlButtonsDisabled = allGroups.every((group) => group.items.length === 0)
+  const dom = GetSourceControlDom.getSourceControlVirtualDom(
+    visibleItems,
+    sourceControlButtons,
+    sourceControlButtonsDisabled,
+    inputPlaceholder,
+    inputMessage,
+    unavailableMessage,
+  )
   return [ViewletCommand.SetDom2, id, dom]
 }

--- a/packages/source-control-worker/src/parts/RenderItems/RenderItems.ts
+++ b/packages/source-control-worker/src/parts/RenderItems/RenderItems.ts
@@ -9,14 +9,6 @@ export const renderItems = (oldState: SourceControlState, newState: SourceContro
     return [ViewletCommand.SetDom2, id, []]
   }
   const unavailableMessage = platform === PlatformType.Web && enabledProviderIds.length === 0 ? SourceControlStrings.noSourceControlProvidersAvailableForWeb() : ''
-  const sourceControlButtonsDisabled = items.length === 0
-  const dom = GetSourceControlDom.getSourceControlVirtualDom(
-    visibleItems,
-    sourceControlButtons,
-    sourceControlButtonsDisabled,
-    inputPlaceholder,
-    inputMessage,
-    unavailableMessage,
-  )
+  const dom = GetSourceControlDom.getSourceControlVirtualDom(visibleItems, sourceControlButtons, items.length === 0, inputPlaceholder, inputMessage, unavailableMessage)
   return [ViewletCommand.SetDom2, id, dom]
 }

--- a/packages/source-control-worker/test/GetSourceControlButtonVirtualDom.test.ts
+++ b/packages/source-control-worker/test/GetSourceControlButtonVirtualDom.test.ts
@@ -4,13 +4,16 @@ import * as ClassNames from '../src/parts/ClassNames/ClassNames.ts'
 import * as DomEventListenerFunctions from '../src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts'
 import { getSourceControlButtonVirtualDom } from '../src/parts/GetSourceControlButtonVirtualDom/GetSourceControlButtonVirtualDom.ts'
 
-test('getSourceControlButtonVirtualDom', () => {
-  const result = getSourceControlButtonVirtualDom({
-    command: 'git.commitAndSync',
-    icon: 'Lock',
-    id: 'git.commitAndSync',
-    label: 'Commit & Sync',
-  })
+test('getSourceControlButtonVirtualDom - enabled', () => {
+  const result = getSourceControlButtonVirtualDom(
+    {
+      command: 'git.commitAndSync',
+      icon: 'Lock',
+      id: 'git.commitAndSync',
+      label: 'Commit & Sync',
+    },
+    false,
+  )
 
   expect(result).toEqual([
     {
@@ -19,11 +22,52 @@ test('getSourceControlButtonVirtualDom', () => {
       type: VirtualDomElements.Div,
     },
     {
+      ariaDisabled: false,
       childCount: 2,
       className: ClassNames.SplitButtonContent,
       name: 'Commit & Sync',
       onClick: DomEventListenerFunctions.HandleClickSourceControlButton,
       tabIndex: 0,
+      title: 'git.commitAndSync',
+      type: VirtualDomElements.Div,
+    },
+    {
+      childCount: 0,
+      className: 'MaskIcon MaskIconLock',
+      role: 'none',
+      type: VirtualDomElements.Span,
+    },
+    {
+      childCount: 0,
+      text: 'Commit & Sync',
+      type: VirtualDomElements.Text,
+    },
+  ])
+})
+
+test('getSourceControlButtonVirtualDom - disabled', () => {
+  const result = getSourceControlButtonVirtualDom(
+    {
+      command: 'git.commitAndSync',
+      icon: 'Lock',
+      id: 'git.commitAndSync',
+      label: 'Commit & Sync',
+    },
+    true,
+  )
+
+  expect(result).toEqual([
+    {
+      childCount: 1,
+      className: `${ClassNames.SplitButton} ${ClassNames.SplitButtonDisabled}`,
+      type: VirtualDomElements.Div,
+    },
+    {
+      ariaDisabled: true,
+      childCount: 2,
+      className: `${ClassNames.SplitButtonContent} ${ClassNames.SplitButtonContentDisabled}`,
+      name: 'Commit & Sync',
+      tabIndex: -1,
       title: 'git.commitAndSync',
       type: VirtualDomElements.Div,
     },

--- a/packages/source-control-worker/test/RenderItems.test.ts
+++ b/packages/source-control-worker/test/RenderItems.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@jest/globals'
 import { PlatformType, ViewletCommand } from '@lvce-editor/constants'
 import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
 import type { SourceControlState } from '../src/parts/SourceControlState/SourceControlState.ts'
+import * as ClassNames from '../src/parts/ClassNames/ClassNames.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as RenderItems from '../src/parts/RenderItems/RenderItems.ts'
 
@@ -132,4 +133,28 @@ test('renderItems - shows unavailable message instead of commit controls in web 
       }),
     ],
   ])
+})
+
+test('renderItems - disables source control buttons without changes', () => {
+  const oldState: SourceControlState = createDefaultState()
+  const newState: SourceControlState = {
+    ...createDefaultState(),
+    sourceControlButtons: [
+      {
+        command: 'git.commitAndSync',
+        icon: 'Check',
+        id: 'git.commitAndSync',
+        label: 'Commit & Sync',
+      },
+    ],
+  }
+
+  const result = RenderItems.renderItems(oldState, newState)
+
+  expect(result[2]).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ className: `${ClassNames.SplitButton} ${ClassNames.SplitButtonDisabled}` }),
+      expect.objectContaining({ ariaDisabled: true, className: `${ClassNames.SplitButtonContent} ${ClassNames.SplitButtonContentDisabled}` }),
+    ]),
+  )
 })

--- a/packages/source-control-worker/test/RenderItems.test.ts
+++ b/packages/source-control-worker/test/RenderItems.test.ts
@@ -151,10 +151,7 @@ test('renderItems - disables source control buttons without changes', () => {
 
   const result = RenderItems.renderItems(oldState, newState)
 
-  expect(result[2]).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({ className: `${ClassNames.SplitButton} ${ClassNames.SplitButtonDisabled}` }),
-      expect.objectContaining({ ariaDisabled: true, className: `${ClassNames.SplitButtonContent} ${ClassNames.SplitButtonContentDisabled}` }),
-    ]),
-  )
+  expect(result[2][3].className).toBe(`${ClassNames.SplitButton} ${ClassNames.SplitButtonDisabled}`)
+  expect(result[2][4].ariaDisabled).toBe(true)
+  expect(result[2][4].className).toBe(`${ClassNames.SplitButtonContent} ${ClassNames.SplitButtonContentDisabled}`)
 })


### PR DESCRIPTION
Disables the source control commit button when every source control group is empty. Reuses the existing disabled split-button styling and removes click and keyboard interaction while exposing the disabled state to assistive technology.