### PR TITLE
fix: reveal source control item in explorer

### DIFF
--- a/packages/e2e/src/source-control.reveal-in-explorer.ts
+++ b/packages/e2e/src/source-control.reveal-in-explorer.ts
@@ -1,0 +1,26 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'source-control.reveal-in-explorer'
+
+export const test: Test = async ({ ContextMenu, expect, Extension, FileSystem, Locator, SourceControl, Workspace }) => {
+  // arrange
+  const extensionUri = import.meta.resolve('../fixtures/sample-source-control-provider')
+  await Extension.addWebExtension(extensionUri)
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/test.css`, 'abc')
+  await Workspace.setPath(tmpDir)
+  await SourceControl.show()
+  const changedFile = Locator('.SourceControlItems .TreeItem[title="test.css"]')
+  await expect(changedFile).toBeVisible()
+
+  // act
+  await SourceControl.handleContextMenu(2, 1, 100)
+  await ContextMenu.selectItem('Reveal in Explorer View')
+
+  // assert
+  const explorer = Locator('.Viewlet.Explorer')
+  await expect(explorer).toBeVisible()
+  const revealedFile = explorer.locator('.TreeItem[aria-label="test.css"]')
+  await expect(revealedFile).toBeVisible()
+  await expect(revealedFile).toHaveId('TreeItemActive')
+}

--- a/packages/source-control-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/source-control-worker/src/parts/CommandMap/CommandMap.ts
@@ -30,6 +30,7 @@ import * as Refresh from '../Refresh/Refresh.ts'
 import * as Render2 from '../Render2/Render2.ts'
 import * as RenderActions2 from '../RenderActions2/RenderActions2.ts'
 import * as RenderEventListeners from '../RenderEventListeners/RenderEventListeners.ts'
+import * as RevealInExplorer from '../RevealInExplorer/RevealInExplorer.ts'
 import * as SaveState from '../SaveState/SaveState.ts'
 import * as SelectIndex from '../SelectIndex/SelectIndex.ts'
 import * as SetDeltaY from '../SetDeltaY/SetDeltaY.ts'
@@ -76,6 +77,7 @@ export const commandMap = {
   'SourceControl.renderActions': WrapCommand.wrapGetter(RenderActions2.renderActions),
   'SourceControl.renderActions2': RenderActions2.renderActions,
   'SourceControl.renderEventListeners': RenderEventListeners.renderEventListeners,
+  'SourceControl.revealInExplorer': WrapCommand.wrapCommand(RevealInExplorer.revealInExplorer),
   'SourceControl.saveState': SaveState.saveState,
   'SourceControl.selectIndex': WrapCommand.wrapCommand(SelectIndex.selectIndex),
   'SourceControl.setDeltaY': WrapCommand.wrapCommand(SetDeltaY.setDeltaY),

--- a/packages/source-control-worker/src/parts/ContextMenuProps/ContextMenuProps.ts
+++ b/packages/source-control-worker/src/parts/ContextMenuProps/ContextMenuProps.ts
@@ -6,6 +6,7 @@ export interface ContextMenuPropsBase {
 
 export interface ContextMenuPropsSourceControl extends ContextMenuPropsBase {
   readonly menuId: typeof MenuEntryId.SourceControl
+  readonly uri: string
 }
 
 export type ContextMenuProps = ContextMenuPropsSourceControl

--- a/packages/source-control-worker/src/parts/GetMenuEntries/GetMenuEntries.ts
+++ b/packages/source-control-worker/src/parts/GetMenuEntries/GetMenuEntries.ts
@@ -42,7 +42,7 @@ export const getMenuEntries = (uri: string): readonly MenuEntry[] => {
     },
     {
       args: [uri],
-      command: 'SourceControl.revealInExplorer',
+      command: 'Source Control.revealInExplorer',
       flags: MenuItemFlags.None,
       id: 'revealInExplorerView',
       label: ViewletSourceControlStrings.revealInExplorerView(),

--- a/packages/source-control-worker/src/parts/GetMenuEntries/GetMenuEntries.ts
+++ b/packages/source-control-worker/src/parts/GetMenuEntries/GetMenuEntries.ts
@@ -2,7 +2,7 @@ import { MenuItemFlags } from '@lvce-editor/constants'
 import type { MenuEntry } from '../MenuEntry/MenuEntry.ts'
 import * as ViewletSourceControlStrings from '../SourceControlStrings/SourceControlStrings.ts'
 
-export const getMenuEntries = (): readonly MenuEntry[] => {
+export const getMenuEntries = (uri: string): readonly MenuEntry[] => {
   return [
     {
       command: /* TODO */ '-1',
@@ -41,9 +41,10 @@ export const getMenuEntries = (): readonly MenuEntry[] => {
       label: ViewletSourceControlStrings.addToGitignore(),
     },
     {
-      command: /* TODO */ '-1',
+      args: [uri],
+      command: 'SourceControl.revealInExplorer',
       flags: MenuItemFlags.None,
-      id: '',
+      id: 'revealInExplorerView',
       label: ViewletSourceControlStrings.revealInExplorerView(),
     },
     {

--- a/packages/source-control-worker/src/parts/GetMenuEntries2/GetMenuEntries2.ts
+++ b/packages/source-control-worker/src/parts/GetMenuEntries2/GetMenuEntries2.ts
@@ -1,7 +1,8 @@
+import type { ContextMenuProps } from '../ContextMenuProps/ContextMenuProps.ts'
 import type { MenuEntry } from '../MenuEntry/MenuEntry.ts'
 import type { SourceControlState } from '../SourceControlState/SourceControlState.ts'
 import { getMenuEntries } from '../GetMenuEntries/GetMenuEntries.ts'
 
-export const getMenuEntries2 = (state: SourceControlState): readonly MenuEntry[] => {
-  return getMenuEntries()
+export const getMenuEntries2 = (state: SourceControlState, props: ContextMenuProps): readonly MenuEntry[] => {
+  return getMenuEntries(props.uri)
 }

--- a/packages/source-control-worker/src/parts/HandleContextMenu/HandleContextMenu.ts
+++ b/packages/source-control-worker/src/parts/HandleContextMenu/HandleContextMenu.ts
@@ -1,11 +1,16 @@
 import { MenuEntryId } from '@lvce-editor/constants'
 import type { SourceControlState } from '../SourceControlState/SourceControlState.ts'
 import * as ContextMenu from '../ContextMenu/ContextMenu.ts'
+import { getIndex } from '../GetIndex/GetIndex.ts'
 
 export const handleContextMenu = async (state: SourceControlState, button: number, x: number, y: number): Promise<SourceControlState> => {
-  const { id } = state
+  const { id, items, root } = state
+  const index = getIndex(state, x, y)
+  const item = items[index]
+  const uri = item?.file ? `${root}/${item.file}` : ''
   await ContextMenu.show2(id, MenuEntryId.SourceControl, x, y, {
     menuId: MenuEntryId.SourceControl,
+    uri,
   })
   return state
 }

--- a/packages/source-control-worker/src/parts/MenuEntry/MenuEntry.ts
+++ b/packages/source-control-worker/src/parts/MenuEntry/MenuEntry.ts
@@ -1,4 +1,5 @@
 export interface MenuEntry {
+  readonly args?: readonly unknown[]
   readonly command: string
   readonly flags: number
   readonly id: string

--- a/packages/source-control-worker/src/parts/RevealInExplorer/RevealInExplorer.ts
+++ b/packages/source-control-worker/src/parts/RevealInExplorer/RevealInExplorer.ts
@@ -1,0 +1,8 @@
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+import type { SourceControlState } from '../SourceControlState/SourceControlState.ts'
+
+export const revealInExplorer = async (state: SourceControlState, uri: string): Promise<SourceControlState> => {
+  await RendererWorker.invoke('SideBar.show', 'Explorer')
+  await RendererWorker.invoke('Explorer.reveal', uri)
+  return state
+}

--- a/packages/source-control-worker/test/ContextMenu.test.ts
+++ b/packages/source-control-worker/test/ContextMenu.test.ts
@@ -10,6 +10,7 @@ test('show2', async (): Promise<void> => {
   using mockRpc = RendererWorker.registerMockRpc(commandMap)
   await ContextMenu.show2(1, MenuEntryId.SourceControl, 2, 3, {
     menuId: MenuEntryId.SourceControl,
+    uri: '/test/test.ts',
   })
-  expect(mockRpc.invocations).toEqual([['ContextMenu.show2', 1, MenuEntryId.SourceControl, 2, 3, { menuId: MenuEntryId.SourceControl }]])
+  expect(mockRpc.invocations).toEqual([['ContextMenu.show2', 1, MenuEntryId.SourceControl, 2, 3, { menuId: MenuEntryId.SourceControl, uri: '/test/test.ts' }]])
 })

--- a/packages/source-control-worker/test/GetMenuEntries.test.ts
+++ b/packages/source-control-worker/test/GetMenuEntries.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@jest/globals'
+import { getMenuEntries } from '../src/parts/GetMenuEntries/GetMenuEntries.ts'
+
+test('reveal in explorer entry', () => {
+  const uri = '/test/src/test.ts'
+  const entries = getMenuEntries(uri)
+  const entry = entries.find((item) => item.id === 'revealInExplorerView')
+
+  expect(entry).toEqual({
+    args: [uri],
+    command: 'SourceControl.revealInExplorer',
+    flags: 0,
+    id: 'revealInExplorerView',
+    label: 'Reveal in Explorer View',
+  })
+})

--- a/packages/source-control-worker/test/GetMenuEntries.test.ts
+++ b/packages/source-control-worker/test/GetMenuEntries.test.ts
@@ -8,7 +8,7 @@ test('reveal in explorer entry', () => {
 
   expect(entry).toEqual({
     args: [uri],
-    command: 'SourceControl.revealInExplorer',
+    command: 'Source Control.revealInExplorer',
     flags: 0,
     id: 'revealInExplorerView',
     label: 'Reveal in Explorer View',

--- a/packages/source-control-worker/test/HandleContextMenu.test.ts
+++ b/packages/source-control-worker/test/HandleContextMenu.test.ts
@@ -1,9 +1,25 @@
 import { expect, test } from '@jest/globals'
 import { MenuEntryId } from '@lvce-editor/constants'
 import { RendererWorker as ParentRpc } from '@lvce-editor/rpc-registry'
+import type { DisplayItem } from '../src/parts/DisplayItem/DisplayItem.ts'
 import type { SourceControlState } from '../src/parts/SourceControlState/SourceControlState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import { handleContextMenu } from '../src/parts/HandleContextMenu/HandleContextMenu.ts'
+
+const fileItem: DisplayItem = {
+  badgeCount: 0,
+  decorationIcon: '',
+  decorationIconTitle: '',
+  decorationStrikeThrough: false,
+  detail: '',
+  file: 'src/test.ts',
+  groupId: 'working-tree',
+  icon: '',
+  label: 'test.ts',
+  posInSet: 1,
+  setSize: 1,
+  type: 8,
+}
 
 test('handleContextMenu', async (): Promise<void> => {
   const commandMap = {
@@ -11,10 +27,17 @@ test('handleContextMenu', async (): Promise<void> => {
   }
   using mockRpc = ParentRpc.registerMockRpc(commandMap)
 
-  const state: SourceControlState = createDefaultState()
+  const state: SourceControlState = {
+    ...createDefaultState(),
+    headerHeight: 50,
+    itemHeight: 30,
+    items: [fileItem],
+    root: '/test',
+    y: 100,
+  }
   const button = 2
   const x = 100
-  const y = 200
+  const y = 150
 
   const newState = await handleContextMenu(state, button, x, y)
   expect(newState).toBe(state)
@@ -27,6 +50,7 @@ test('handleContextMenu', async (): Promise<void> => {
       y,
       {
         menuId: MenuEntryId.SourceControl,
+        uri: '/test/src/test.ts',
       },
     ],
   ])

--- a/packages/source-control-worker/test/RevealInExplorer.test.ts
+++ b/packages/source-control-worker/test/RevealInExplorer.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@jest/globals'
+import { RendererWorker as ParentRpc } from '@lvce-editor/rpc-registry'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import { revealInExplorer } from '../src/parts/RevealInExplorer/RevealInExplorer.ts'
+
+test('revealInExplorer', async () => {
+  const commandMap = {
+    'Explorer.reveal': async (): Promise<void> => {},
+    'SideBar.show': async (): Promise<void> => {},
+  }
+  using mockRpc = ParentRpc.registerMockRpc(commandMap)
+  const state = createDefaultState()
+  const uri = '/test/src/test.ts'
+
+  const newState = await revealInExplorer(state, uri)
+
+  expect(newState).toBe(state)
+  expect(mockRpc.invocations).toEqual([
+    ['SideBar.show', 'Explorer'],
+    ['Explorer.reveal', uri],
+  ])
+})


### PR DESCRIPTION
Fix the source-control item context-menu action so it switches to Explorer and reveals the selected changed file. Adds unit coverage and an end-to-end regression test for the full menu flow.