### PR TITLE
fix: add padding to no provider message

### DIFF
--- a/packages/e2e/src/source-control.no-provider-padding.ts
+++ b/packages/e2e/src/source-control.no-provider-padding.ts
@@ -1,0 +1,15 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'source-control.no-provider-padding'
+
+export const test: Test = async ({ expect, Locator, SourceControl }) => {
+  // act
+  await SourceControl.show()
+
+  // assert
+  const message = Locator('.Viewlet.SourceControl > .Message')
+  await expect(message).toBeVisible()
+  await expect(message).toHaveText('No source control provider is enabled or installed.')
+  await expect(message).toHaveCSS('padding-left', '20px')
+  await expect(message).toHaveCSS('padding-right', '20px')
+}

--- a/packages/source-control-worker/src/parts/GetSourceControlVirtualDom/GetSourceControlVirtualDom.ts
+++ b/packages/source-control-worker/src/parts/GetSourceControlVirtualDom/GetSourceControlVirtualDom.ts
@@ -25,6 +25,8 @@ export const getSourceControlVirtualDom = (
         {
           childCount: 1,
           className: ClassNames.Message,
+          paddingLeft: '20px',
+          paddingRight: '20px',
           type: VirtualDomElements.Div,
         },
         text(message),

--- a/packages/source-control-worker/test/RenderItems.test.ts
+++ b/packages/source-control-worker/test/RenderItems.test.ts
@@ -125,7 +125,11 @@ test('renderItems - shows unavailable message instead of commit controls without
     1,
     [
       expect.objectContaining({ childCount: 1 }),
-      expect.objectContaining({ childCount: 1 }),
+      expect.objectContaining({
+        childCount: 1,
+        paddingLeft: '20px',
+        paddingRight: '20px',
+      }),
       expect.objectContaining({
         text: 'No source control provider is enabled or installed.',
         type: VirtualDomElements.Text,


### PR DESCRIPTION
Summary:
- add explicit horizontal padding to the no-provider empty-state message
- cover the message text and computed padding with an e2e regression test