### PR TITLE
test: cover opening source control changes

### DIFF
--- a/packages/e2e/src/source-control.open-changes-diff.ts
+++ b/packages/e2e/src/source-control.open-changes-diff.ts
@@ -1,0 +1,24 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'source-control.open-changes-diff'
+
+export const test: Test = async ({ expect, Extension, FileSystem, Locator, SourceControl, Workspace }) => {
+  const uri = import.meta.resolve('../fixtures/sample-source-control-provider')
+  await Extension.addWebExtension(uri)
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/test.css`, 'abc')
+  await Workspace.setPath(tmpDir)
+
+  await SourceControl.show()
+
+  const fileItem = Locator('.SourceControlItems .TreeItem').nth(1)
+  await expect(fileItem).toHaveText('test.css')
+  await SourceControl.selectIndex(1)
+
+  const diffEditor = Locator('.DiffEditor')
+  const changedContent = Locator('.DiffEditorContentRight .DiffEditorRows')
+  const errorMessage = Locator('.DiffEditorErrorMessage')
+  await expect(diffEditor).toBeVisible()
+  await expect(changedContent).toContainText('abc')
+  await expect(errorMessage).toHaveCount(0)
+}


### PR DESCRIPTION
## Summary

Add end-to-end coverage for opening a changed file from Source Control and rendering its diff. The test verifies the changed content is visible and no diff editor error is shown.

This guards the integration path affected by lvce-editor/lvce-editor#12330.

## Validation

- npm run build
- npm run build:static
- npm test
- npm run test-integration
- npm run type-check
- npm run lint
- focused Chromium e2e
- memory measurement