### PR TITLE
fix: open correct source control item after scrolling

### DIFF
--- a/packages/e2e/src/source-control.many-items.ts
+++ b/packages/e2e/src/source-control.many-items.ts
@@ -32,4 +32,15 @@ export const test: Test = async ({ Command, expect, Extension, FileSystem, Locat
 
   // assert
   await expect(scrollBarThumb).toHaveCSS('translate', '0px 6px')
+
+  // act
+  const visibleFileItem = Locator('.SourceControlItems .TreeItem', { hasText: '10.txt' })
+  await expect(visibleFileItem).toBeVisible()
+  await Command.execute('Source Control.handleClickAt', 0, 145, '')
+
+  // assert
+  const diffEditor = Locator('.DiffEditor')
+  const changedContent = Locator('.DiffEditorContentRight .DiffEditorRows')
+  await expect(diffEditor).toBeVisible()
+  await expect(changedContent).toContainText('10')
 }

--- a/packages/source-control-worker/src/parts/GetIndex/GetIndex.ts
+++ b/packages/source-control-worker/src/parts/GetIndex/GetIndex.ts
@@ -1,8 +1,8 @@
 import type { SourceControlState } from '../SourceControlState/SourceControlState.ts'
 
 export const getIndex = (state: SourceControlState, eventX: number, eventY: number): number => {
-  const { headerHeight, itemHeight, y } = state
+  const { deltaY, headerHeight, itemHeight, y } = state
   const relativeY = eventY - y - headerHeight
-  const index = Math.floor(relativeY / itemHeight)
+  const index = Math.floor((relativeY + deltaY) / itemHeight)
   return index
 }

--- a/packages/source-control-worker/src/parts/HandleClickAt/HandleClickAt.ts
+++ b/packages/source-control-worker/src/parts/HandleClickAt/HandleClickAt.ts
@@ -4,9 +4,10 @@ import { handleClickSourceControlButtons } from '../HandleClickSourceControlButt
 import * as SelectIndex from '../SelectIndex/SelectIndex.ts'
 
 export const handleClickAt = async (state: SourceControlState, eventX: number, eventY: number, name: string): Promise<SourceControlState> => {
+  const { minLineY } = state
   const index = getIndex(state, eventX, eventY)
   if (name) {
-    return handleClickSourceControlButtons(state, index, name)
+    return handleClickSourceControlButtons(state, index - minLineY, name)
   }
   return SelectIndex.selectIndex(state, index)
 }

--- a/packages/source-control-worker/test/GetIndex.test.ts
+++ b/packages/source-control-worker/test/GetIndex.test.ts
@@ -54,3 +54,27 @@ test('getIndex - different header height', () => {
   const result = getIndex(state, eventX, eventY)
   expect(result).toBe(1)
 })
+
+test('getIndex - scrolled', () => {
+  const state: SourceControlState = {
+    ...createDefaultState(),
+    deltaY: 60,
+    headerHeight: 50,
+    itemHeight: 30,
+    y: 100,
+  }
+  const result = getIndex(state, 0, 150)
+  expect(result).toBe(2)
+})
+
+test('getIndex - fractionally scrolled into next item', () => {
+  const state: SourceControlState = {
+    ...createDefaultState(),
+    deltaY: 50,
+    headerHeight: 50,
+    itemHeight: 30,
+    y: 100,
+  }
+  const result = getIndex(state, 0, 160)
+  expect(result).toBe(2)
+})


### PR DESCRIPTION
Fix source control hit testing so clicks resolve against the full scrolled list, including fractional row offsets. Preserve visible-row indexing for inline actions and cover opening the correct diff after scrolling a large change set.