### PR TITLE
Reuse page for source control e2e tests

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "e2e": "node ./node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js  --only-extension=. --test-path=.",
-    "e2e:headless": "node ./node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js  --only-extension=. --test-path=. --headless",
+    "e2e": "node ./node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js  --only-extension=. --test-path=. --reuse-page",
+    "e2e:headless": "node ./node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js  --only-extension=. --test-path=. --headless --reuse-page",
     "type-check": "tsc"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Enable reused-page execution for both interactive and headless Source Control end-to-end tests.