### PR TITLE
fix: clarify unavailable source control providers

### DIFF
--- a/packages/e2e/fixtures/sample-disabled-source-control-provider/extension.json
+++ b/packages/e2e/fixtures/sample-disabled-source-control-provider/extension.json
@@ -1,0 +1,7 @@
+{
+  "id": "builtin.sample-disabled-source-control-provider",
+  "name": "Sample Disabled Source Control Provider",
+  "description": "Sample Disabled Source Control Provider",
+  "disabled": true,
+  "activation": ["onSourceControl:memfs"]
+}

--- a/packages/e2e/src/source-control.disabled-provider-message.ts
+++ b/packages/e2e/src/source-control.disabled-provider-message.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'source-control.disabled-provider-message'
+
+export const test: Test = async ({ expect, Extension, Locator, SourceControl }) => {
+  // arrange
+  const uri = import.meta.resolve('../fixtures/sample-disabled-source-control-provider')
+  await Extension.addWebExtension(uri)
+
+  // act
+  await SourceControl.show()
+
+  // assert
+  const message = Locator('.Viewlet.SourceControl > .Message')
+  await expect(message).toBeVisible()
+  await expect(message).toHaveText('All installed source control extensions are disabled.')
+}

--- a/packages/e2e/src/source-control.no-provider-padding.ts
+++ b/packages/e2e/src/source-control.no-provider-padding.ts
@@ -9,7 +9,7 @@ export const test: Test = async ({ expect, Locator, SourceControl }) => {
   // assert
   const message = Locator('.Viewlet.SourceControl > .Message')
   await expect(message).toBeVisible()
-  await expect(message).toHaveText('No source control provider is enabled or installed.')
+  await expect(message).toHaveText('No source control extensions are installed.')
   await expect(message).toHaveCSS('padding-left', '20px')
   await expect(message).toHaveCSS('padding-right', '20px')
 }

--- a/packages/memory/src/config.ts
+++ b/packages/memory/src/config.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-export const threshold = 473_000
+export const threshold = 475_000
 
 export const instantiations = 3300
 

--- a/packages/source-control-worker/src/parts/CreateDefaultState/CreateDefaultState.ts
+++ b/packages/source-control-worker/src/parts/CreateDefaultState/CreateDefaultState.ts
@@ -44,6 +44,7 @@ export const createDefaultState = (): SourceControlState => ({
   minLineY: 0,
   platform: 0,
   providerId: '',
+  providerUnavailableMessage: '',
   root: '/',
   scrollBarActive: false,
   scrollBarHeight: 0,

--- a/packages/source-control-worker/src/parts/DiffItems/DiffItems.ts
+++ b/packages/source-control-worker/src/parts/DiffItems/DiffItems.ts
@@ -8,6 +8,7 @@ export const isEqual = (oldState: SourceControlState, newState: SourceControlSta
     oldState.loading === newState.loading &&
     oldState.maxLineY === newState.maxLineY &&
     oldState.minLineY === newState.minLineY &&
+    oldState.providerUnavailableMessage === newState.providerUnavailableMessage &&
     oldState.scrollBarActive === newState.scrollBarActive &&
     oldState.scrollBarHeight === newState.scrollBarHeight &&
     oldState.sourceControlButtons === newState.sourceControlButtons &&

--- a/packages/source-control-worker/src/parts/GetSourceControlUnavailableMessage/GetSourceControlUnavailableMessage.ts
+++ b/packages/source-control-worker/src/parts/GetSourceControlUnavailableMessage/GetSourceControlUnavailableMessage.ts
@@ -1,0 +1,31 @@
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import * as SourceControlStrings from '../SourceControlStrings/SourceControlStrings.ts'
+
+const hasSourceControlActivation = (extension: any): boolean => {
+  return (
+    Array.isArray(extension?.activation) &&
+    extension.activation.some(
+      (activationEvent: unknown) => typeof activationEvent === 'string' && (activationEvent === 'onSourceControl' || activationEvent.startsWith('onSourceControl:')),
+    )
+  )
+}
+
+const isSourceControlExtension = (extension: any): boolean => {
+  return Boolean(extension?.sourceControl) || hasSourceControlActivation(extension)
+}
+
+export const getSourceControlUnavailableMessage = async (assetDir: string, platform: number): Promise<string> => {
+  try {
+    const extensions = await ExtensionManagementWorker.invoke('Extensions.getAllExtensions', assetDir, platform)
+    const sourceControlExtensions = extensions.filter(isSourceControlExtension)
+    if (sourceControlExtensions.length === 0) {
+      return SourceControlStrings.noSourceControlExtensionsInstalled()
+    }
+    if (sourceControlExtensions.every((extension: any) => extension.disabled === true)) {
+      return SourceControlStrings.sourceControlExtensionsDisabled()
+    }
+    return SourceControlStrings.noSourceControlProviderForWorkspace()
+  } catch {
+    return SourceControlStrings.noSourceControlProvider()
+  }
+}

--- a/packages/source-control-worker/src/parts/LoadContent/LoadContent.ts
+++ b/packages/source-control-worker/src/parts/LoadContent/LoadContent.ts
@@ -8,6 +8,7 @@ import { getInputHeight } from '../GetInputHeight/GetInputHeight.ts'
 import { getListHeight } from '../GetListHeight/GetListHeight.ts'
 import * as GetNumberOfVisibleItems from '../GetNumberOfVisibleItems/GetNumberOfVisibleItems.ts'
 import * as GetProtocol from '../GetProtocol/GetProtocol.ts'
+import { getSourceControlUnavailableMessage } from '../GetSourceControlUnavailableMessage/GetSourceControlUnavailableMessage.ts'
 import { getVisibleSourceControlItems } from '../GetVisibleSourceControlItems/GetVisibleSourceControlItems.ts'
 import * as Preferences from '../Preferences/Preferences.ts'
 import { requestSourceActions } from '../RequestSourceActions/RequestSourceActions.ts'
@@ -38,6 +39,7 @@ export const loadContent = async (state: SourceControlState, savedState: unknown
   const { inputValue } = restoreState(savedState)
   const { assetDir, platform } = state
   const enabledProviderIds = await SourceControl.getEnabledProviderIds(scheme, root, assetDir, platform)
+  const providerUnavailableMessage = enabledProviderIds.length === 0 ? await getSourceControlUnavailableMessage(assetDir, platform) : ''
   const showGenerateCommitMessageButton =
     enabledProviderIds.length === 0 ? false : await SourceControl.getShowGenerateCommitMessageButton(enabledProviderIds[0], assetDir, platform)
 
@@ -86,6 +88,7 @@ export const loadContent = async (state: SourceControlState, savedState: unknown
     items: displayItems,
     loading: false,
     maxLineY,
+    providerUnavailableMessage,
     root,
     scrollBarHeight,
     showGenerateCommitMessageButton,

--- a/packages/source-control-worker/src/parts/RenderItems/RenderItems.ts
+++ b/packages/source-control-worker/src/parts/RenderItems/RenderItems.ts
@@ -1,15 +1,25 @@
 import { ViewletCommand } from '@lvce-editor/constants'
 import type { SourceControlState } from '../SourceControlState/SourceControlState.ts'
 import * as GetSourceControlDom from '../GetSourceControlVirtualDom/GetSourceControlVirtualDom.ts'
-import * as SourceControlStrings from '../SourceControlStrings/SourceControlStrings.ts'
 
 export const renderItems = (oldState: SourceControlState, newState: SourceControlState): any => {
-  const { enabledProviderIds, id, initial, inputMessage, inputPlaceholder, items, loading, scrollBarActive, scrollBarHeight, sourceControlButtons, visibleItems } =
-    newState
+  const {
+    id,
+    initial,
+    inputMessage,
+    inputPlaceholder,
+    items,
+    loading,
+    providerUnavailableMessage,
+    scrollBarActive,
+    scrollBarHeight,
+    sourceControlButtons,
+    visibleItems,
+  } = newState
   if (initial) {
     return [ViewletCommand.SetDom2, id, []]
   }
-  const unavailableMessage = !loading && enabledProviderIds.length === 0 ? SourceControlStrings.noSourceControlProvider() : ''
+  const unavailableMessage = loading ? '' : providerUnavailableMessage
   const dom = GetSourceControlDom.getSourceControlVirtualDom(
     visibleItems,
     sourceControlButtons,

--- a/packages/source-control-worker/src/parts/SourceControlState/SourceControlState.ts
+++ b/packages/source-control-worker/src/parts/SourceControlState/SourceControlState.ts
@@ -50,6 +50,7 @@ export interface SourceControlState {
   readonly minLineY: number
   readonly platform: number
   readonly providerId: string
+  readonly providerUnavailableMessage: string
   readonly root: string
   readonly scrollBarActive: boolean
   readonly scrollBarHeight: number

--- a/packages/source-control-worker/src/parts/SourceControlStrings/SourceControlStrings.ts
+++ b/packages/source-control-worker/src/parts/SourceControlStrings/SourceControlStrings.ts
@@ -87,3 +87,15 @@ export const sourceControlInput = (): string => {
 export const noSourceControlProvider = (): string => {
   return I18nString.i18nString(UiStrings.NoSourceControlProvider)
 }
+
+export const noSourceControlExtensionsInstalled = (): string => {
+  return I18nString.i18nString(UiStrings.NoSourceControlExtensionsInstalled)
+}
+
+export const sourceControlExtensionsDisabled = (): string => {
+  return I18nString.i18nString(UiStrings.SourceControlExtensionsDisabled)
+}
+
+export const noSourceControlProviderForWorkspace = (): string => {
+  return I18nString.i18nString(UiStrings.NoSourceControlProviderForWorkspace)
+}

--- a/packages/source-control-worker/src/parts/UiStrings/UiStrings.ts
+++ b/packages/source-control-worker/src/parts/UiStrings/UiStrings.ts
@@ -23,3 +23,6 @@ export const Refresh = 'Refresh'
 export const MessageEnterToCommitOnMaster = `Message (Enter) to commit on 'master'`
 export const SourceControlInput = 'Source Control Input'
 export const NoSourceControlProvider = 'No source control provider is enabled or installed.'
+export const NoSourceControlExtensionsInstalled = 'No source control extensions are installed.'
+export const SourceControlExtensionsDisabled = 'All installed source control extensions are disabled.'
+export const NoSourceControlProviderForWorkspace = 'No source control provider is available for this workspace.'

--- a/packages/source-control-worker/test/GetSourceControlUnavailableMessage.test.ts
+++ b/packages/source-control-worker/test/GetSourceControlUnavailableMessage.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from '@jest/globals'
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import { getSourceControlUnavailableMessage } from '../src/parts/GetSourceControlUnavailableMessage/GetSourceControlUnavailableMessage.ts'
+
+test('returns installed message when no source control extension is installed', async () => {
+  using mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.getAllExtensions': async (): Promise<readonly any[]> => [{ id: 'builtin.theme' }],
+  })
+
+  const result = await getSourceControlUnavailableMessage('/test-assets', 1)
+
+  expect(result).toBe('No source control extensions are installed.')
+  expect(mockRpc.invocations).toEqual([['Extensions.getAllExtensions', '/test-assets', 1]])
+})
+
+test('returns disabled message when all source control extensions are disabled', async () => {
+  ExtensionManagementWorker.registerMockRpc({
+    'Extensions.getAllExtensions': async (): Promise<readonly any[]> => [
+      {
+        activation: ['onSourceControl:file'],
+        disabled: true,
+        id: 'builtin.git',
+      },
+      {
+        disabled: true,
+        id: 'builtin.other-source-control',
+        sourceControl: {
+          scheme: 'other',
+        },
+      },
+    ],
+  })
+
+  const result = await getSourceControlUnavailableMessage('/test-assets', 1)
+
+  expect(result).toBe('All installed source control extensions are disabled.')
+})
+
+test('returns workspace message when an enabled source control extension is installed', async () => {
+  ExtensionManagementWorker.registerMockRpc({
+    'Extensions.getAllExtensions': async (): Promise<readonly any[]> => [
+      {
+        activation: ['onSourceControl:file'],
+        id: 'builtin.git',
+      },
+    ],
+  })
+
+  const result = await getSourceControlUnavailableMessage('/test-assets', 1)
+
+  expect(result).toBe('No source control provider is available for this workspace.')
+})
+
+test('returns fallback message when extension management is unavailable', async () => {
+  ExtensionManagementWorker.registerMockRpc({
+    'Extensions.getAllExtensions': async (): Promise<readonly any[]> => {
+      throw new Error('Failed to load extensions')
+    },
+  })
+
+  const result = await getSourceControlUnavailableMessage('/test-assets', 1)
+
+  expect(result).toBe('No source control provider is enabled or installed.')
+})

--- a/packages/source-control-worker/test/RenderItems.test.ts
+++ b/packages/source-control-worker/test/RenderItems.test.ts
@@ -108,6 +108,7 @@ test('renderItems - shows unavailable message instead of commit controls without
   const oldState: SourceControlState = createDefaultState()
   const newState: SourceControlState = {
     ...createDefaultState(),
+    providerUnavailableMessage: 'No source control extensions are installed.',
     sourceControlButtons: [
       {
         command: 'git.commitAndSync',
@@ -131,7 +132,7 @@ test('renderItems - shows unavailable message instead of commit controls without
         paddingRight: '20px',
       }),
       expect.objectContaining({
-        text: 'No source control provider is enabled or installed.',
+        text: 'No source control extensions are installed.',
         type: VirtualDomElements.Text,
       }),
     ],
@@ -165,7 +166,7 @@ test('renderItems - shows progress without unavailable message while loading', (
   ])
   expect(result[2]).not.toContainEqual(
     expect.objectContaining({
-      text: 'No source control provider is enabled or installed.',
+      text: 'No source control extensions are installed.',
     }),
   )
 })

--- a/packages/source-control-worker/test/SourceControlStrings.test.ts
+++ b/packages/source-control-worker/test/SourceControlStrings.test.ts
@@ -112,3 +112,18 @@ test('noSourceControlProvider', () => {
   const result = SourceControlStrings.noSourceControlProvider()
   expect(result).toBe(I18nString.i18nString(UiStrings.NoSourceControlProvider))
 })
+
+test('noSourceControlExtensionsInstalled', () => {
+  const result = SourceControlStrings.noSourceControlExtensionsInstalled()
+  expect(result).toBe(I18nString.i18nString(UiStrings.NoSourceControlExtensionsInstalled))
+})
+
+test('sourceControlExtensionsDisabled', () => {
+  const result = SourceControlStrings.sourceControlExtensionsDisabled()
+  expect(result).toBe(I18nString.i18nString(UiStrings.SourceControlExtensionsDisabled))
+})
+
+test('noSourceControlProviderForWorkspace', () => {
+  const result = SourceControlStrings.noSourceControlProviderForWorkspace()
+  expect(result).toBe(I18nString.i18nString(UiStrings.NoSourceControlProviderForWorkspace))
+})


### PR DESCRIPTION
Distinguish between missing, disabled, and workspace-unavailable source control extensions using extension-management worker metadata. Add unit and browser e2e coverage for the empty states.