### PR TITLE
fix: handle source control button icon clicks

### DIFF
--- a/packages/source-control-worker/src/parts/GetSourceControlButtonVirtualDom/GetSourceControlButtonVirtualDom.ts
+++ b/packages/source-control-worker/src/parts/GetSourceControlButtonVirtualDom/GetSourceControlButtonVirtualDom.ts
@@ -25,7 +25,10 @@ export const getSourceControlButtonVirtualDom = (button: ActionButton, disabled:
       type: VirtualDomElements.Div,
       ...(!disabled && { onClick: DomEventListenerFunctions.HandleClickSourceControlButton }),
     },
-    GetIconVirtualDom.getIconVirtualDom(icon, VirtualDomElements.Span),
+    {
+      ...GetIconVirtualDom.getIconVirtualDom(icon, VirtualDomElements.Span),
+      name: label,
+    },
     text(label),
   ]
 }

--- a/packages/source-control-worker/test/GetSourceControlButtonVirtualDom.test.ts
+++ b/packages/source-control-worker/test/GetSourceControlButtonVirtualDom.test.ts
@@ -34,6 +34,7 @@ test('getSourceControlButtonVirtualDom - enabled', () => {
     {
       childCount: 0,
       className: 'MaskIcon MaskIconLock',
+      name: 'Commit & Sync',
       role: 'none',
       type: VirtualDomElements.Span,
     },
@@ -74,6 +75,7 @@ test('getSourceControlButtonVirtualDom - disabled', () => {
     {
       childCount: 0,
       className: 'MaskIcon MaskIconLock',
+      name: 'Commit & Sync',
       role: 'none',
       type: VirtualDomElements.Span,
     },


### PR DESCRIPTION
Fixes Commit & Sync clicks on the nested lock icon by preserving the source-control button name on the event target. Adds focused virtual-DOM regression coverage.