### PR TITLE
fix: load source control extension metadata

### DIFF
--- a/packages/source-control-worker/src/parts/ExtensionMeta/ExtensionMeta.ts
+++ b/packages/source-control-worker/src/parts/ExtensionMeta/ExtensionMeta.ts
@@ -1,11 +1,11 @@
 import { PlatformType } from '@lvce-editor/constants'
-import { ExtensionHost } from '@lvce-editor/rpc-registry'
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 
 const isCompatible = (extension: any, platform: number): boolean => {
   return platform !== PlatformType.Web || extension?.compatibility?.web !== false
 }
 
-export const getExtensions = async (platform: number): Promise<readonly any[]> => {
-  const extensions = await ExtensionHost.invoke('Extensions.getExtensions')
+export const getExtensions = async (assetDir: string, platform: number): Promise<readonly any[]> => {
+  const extensions = await ExtensionManagementWorker.invoke('Extensions.getAllExtensions', assetDir, platform)
   return extensions.filter((extension: any) => isCompatible(extension, platform))
 }

--- a/packages/source-control-worker/src/parts/LoadContent/LoadContent.ts
+++ b/packages/source-control-worker/src/parts/LoadContent/LoadContent.ts
@@ -49,8 +49,8 @@ export const loadContent = async (state: SourceControlState, savedState: unknown
   const expandedGroups = restoreExpandedGroups(allGroups)
   const displayItems = getDisplayItems(allGroups, expandedGroups, iconDefinitions)
 
-  const actionsCache = enabledProviderIds.length === 0 ? Object.create(null) : await requestSourceActions(platform)
-  const sourceControlButtons = enabledProviderIds.length === 0 ? [] : await requestSourceControlButtons(platform)
+  const actionsCache = enabledProviderIds.length === 0 ? Object.create(null) : await requestSourceActions(assetDir, platform)
+  const sourceControlButtons = enabledProviderIds.length === 0 ? [] : await requestSourceControlButtons(assetDir, platform)
 
   // TODO make preferences async and more functional
   const splitButtonEnabled = await Preferences.get('sourceControl.splitButtonEnabled')

--- a/packages/source-control-worker/src/parts/RequestSourceActions/RequestSourceActions.ts
+++ b/packages/source-control-worker/src/parts/RequestSourceActions/RequestSourceActions.ts
@@ -1,8 +1,8 @@
 import type { ActionsCache } from '../ActionsCache/ActionsCache.ts'
 import * as ExtensionMeta from '../ExtensionMeta/ExtensionMeta.ts'
 
-export const requestSourceActions = async (platform = 0): Promise<ActionsCache> => {
-  const extensions = await ExtensionMeta.getExtensions(platform)
+export const requestSourceActions = async (assetDir = '', platform = 0): Promise<ActionsCache> => {
+  const extensions = await ExtensionMeta.getExtensions(assetDir, platform)
   const newCache = Object.create(null)
   for (const extension of extensions) {
     if (!extension || !extension['source-control-actions']) {

--- a/packages/source-control-worker/src/parts/RequestSourceControlButtons/RequestSourceControlButtons.ts
+++ b/packages/source-control-worker/src/parts/RequestSourceControlButtons/RequestSourceControlButtons.ts
@@ -1,8 +1,8 @@
 import type { ActionButton } from '../ActionButton/ActionButton.ts'
 import * as ExtensionMeta from '../ExtensionMeta/ExtensionMeta.ts'
 
-export const requestSourceControlButtons = async (platform = 0): Promise<readonly ActionButton[]> => {
-  const extensions = await ExtensionMeta.getExtensions(platform)
+export const requestSourceControlButtons = async (assetDir = '', platform = 0): Promise<readonly ActionButton[]> => {
+  const extensions = await ExtensionMeta.getExtensions(assetDir, platform)
   const buttons: ActionButton[] = []
   for (const extension of extensions) {
     if (!extension || !Array.isArray(extension['source-control-buttons'])) {

--- a/packages/source-control-worker/test/HandleButtonClick.test.ts
+++ b/packages/source-control-worker/test/HandleButtonClick.test.ts
@@ -14,7 +14,6 @@ test('handleButtonClick - valid button click', async (): Promise<void> => {
       gitRoot: '',
     }),
     'ExtensionHostSourceControl.getIconDefinitions': async (): Promise<never[]> => [],
-    'Extensions.getExtensions': async (): Promise<never[]> => [],
   }
   const extensionHostMockRpc = ExtensionHost.registerMockRpc(extensionHostCommandMap)
 

--- a/packages/source-control-worker/test/HandleSourceControlButtonClick.test.ts
+++ b/packages/source-control-worker/test/HandleSourceControlButtonClick.test.ts
@@ -9,7 +9,6 @@ test('handleSourceControlButtonClick', async () => {
     'ExtensionHostCommand.executeCommand': async (): Promise<void> => {},
     'ExtensionHostManagement.activateByEvent': async (): Promise<void> => {},
     'ExtensionHostSourceControl.getEnabledProviderIds': async (): Promise<readonly string[]> => [],
-    'Extensions.getExtensions': async (): Promise<readonly any[]> => [],
     'IconTheme.getIcons': async (): Promise<readonly string[]> => [],
     'MeasureTextHeight.measureTextBlockHeight': async (): Promise<number> => 30,
     'Preferences.get': async (): Promise<any> => false,

--- a/packages/source-control-worker/test/HandleWorkspaceRefresh.test.ts
+++ b/packages/source-control-worker/test/HandleWorkspaceRefresh.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@jest/globals'
-import { ExtensionHost, RendererWorker } from '@lvce-editor/rpc-registry'
+import { ExtensionHost, ExtensionManagementWorker, RendererWorker } from '@lvce-editor/rpc-registry'
 import type { SourceControlState } from '../src/parts/SourceControlState/SourceControlState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import { handleWorkspaceRefresh } from '../src/parts/HandleWorkspaceRefresh/HandleWorkspaceRefresh.ts'
@@ -12,9 +12,11 @@ test('handleWorkspaceRefresh should discover newly available source control prov
     }),
     'ExtensionHostSourceControl.getGroups': async (): Promise<readonly never[]> => [],
     'ExtensionHostSourceControl.getIconDefinitions': async (): Promise<readonly string[]> => [],
-    'Extensions.getExtensions': async (): Promise<readonly unknown[]> => [],
   }
   using mockRpc = ExtensionHost.registerMockRpc(extensionHostCommandMap)
+  using extensionManagementMockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.getAllExtensions': async (): Promise<readonly unknown[]> => [],
+  })
 
   const rendererCommandMap = {
     'ExtensionHostManagement.activateByEvent': async (): Promise<void> => {},
@@ -35,6 +37,10 @@ test('handleWorkspaceRefresh should discover newly available source control prov
   expect(result.enabledProviderIds).toEqual(['git'])
   expect(result.inputValue).toBe('existing commit message')
   expect(mockRpc.invocations).toContainEqual(['ExtensionHostSourceControl.getEnabledProviderIds', 'file', '/test'])
+  expect(extensionManagementMockRpc.invocations).toEqual([
+    ['Extensions.getAllExtensions', '', 0],
+    ['Extensions.getAllExtensions', '', 0],
+  ])
 })
 
 test('handleWorkspaceRefresh should use the lightweight refresh when providers are unchanged', async (): Promise<void> => {

--- a/packages/source-control-worker/test/LoadContent.test.ts
+++ b/packages/source-control-worker/test/LoadContent.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from '@jest/globals'
-import { ExtensionHost } from '@lvce-editor/rpc-registry'
-import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { ExtensionHost, ExtensionManagementWorker, RendererWorker } from '@lvce-editor/rpc-registry'
 import type { SourceControlState } from '../src/parts/SourceControlState/SourceControlState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import { loadContent } from '../src/parts/LoadContent/LoadContent.ts'
@@ -9,12 +8,13 @@ test('loadContent - basic with empty state', async (): Promise<void> => {
   const commandMap = {
     'ExtensionHostManagement.activateByEvent': async (): Promise<void> => {},
     'ExtensionHostSourceControl.getEnabledProviderIds': async (): Promise<readonly string[]> => [],
-    'Extensions.getExtensions': async (): Promise<readonly any[]> => [],
+    'Extensions.getAllExtensions': async (): Promise<readonly any[]> => [],
     'IconTheme.getIcons': async (): Promise<readonly string[]> => [],
     'MeasureTextHeight.measureTextBlockHeight': async (): Promise<number> => 30,
     'Preferences.get': async (): Promise<any> => false,
   }
   ExtensionHost.registerMockRpc(commandMap)
+  ExtensionManagementWorker.registerMockRpc(commandMap)
   RendererWorker.registerMockRpc(commandMap)
 
   const state: SourceControlState = createDefaultState()
@@ -35,12 +35,13 @@ test('loadContent - with saved state inputValue', async (): Promise<void> => {
   const commandMap = {
     'ExtensionHostManagement.activateByEvent': async (): Promise<void> => {},
     'ExtensionHostSourceControl.getEnabledProviderIds': async (): Promise<readonly string[]> => [],
-    'Extensions.getExtensions': async (): Promise<readonly any[]> => [],
+    'Extensions.getAllExtensions': async (): Promise<readonly any[]> => [],
     'IconTheme.getIcons': async (): Promise<readonly string[]> => [],
     'MeasureTextHeight.measureTextBlockHeight': async (): Promise<number> => 45,
     'Preferences.get': async (): Promise<any> => false,
   }
   ExtensionHost.registerMockRpc(commandMap)
+  ExtensionManagementWorker.registerMockRpc(commandMap)
   RendererWorker.registerMockRpc(commandMap)
 
   const state: SourceControlState = createDefaultState()
@@ -60,12 +61,13 @@ test('loadContent - with enabled providers', async (): Promise<void> => {
     'ExtensionHostSourceControl.getFeatures': async (): Promise<{ showGenerateCommitMessageButton: boolean }> => ({ showGenerateCommitMessageButton: false }),
     'ExtensionHostSourceControl.getGroups': async (): Promise<readonly any[]> => [],
     'ExtensionHostSourceControl.getIconDefinitions': async (): Promise<readonly string[]> => ['icon1', 'icon2'],
-    'Extensions.getExtensions': async (): Promise<readonly any[]> => [],
+    'Extensions.getAllExtensions': async (): Promise<readonly any[]> => [],
     'IconTheme.getIcons': async (): Promise<readonly string[]> => [],
     'MeasureTextHeight.measureTextBlockHeight': async (): Promise<number> => 30,
     'Preferences.get': async (): Promise<any> => false,
   }
   ExtensionHost.registerMockRpc(commandMap)
+  ExtensionManagementWorker.registerMockRpc(commandMap)
   RendererWorker.registerMockRpc(commandMap)
 
   const state: SourceControlState = {
@@ -101,12 +103,13 @@ test('loadContent - with groups', async (): Promise<void> => {
     'ExtensionHostSourceControl.getEnabledProviderIds': async (): Promise<readonly string[]> => ['git'],
     'ExtensionHostSourceControl.getGroups': async (): Promise<readonly any[]> => mockGroups,
     'ExtensionHostSourceControl.getIconDefinitions': async (): Promise<readonly string[]> => [],
-    'Extensions.getExtensions': async (): Promise<readonly any[]> => [],
+    'Extensions.getAllExtensions': async (): Promise<readonly any[]> => [],
     'IconTheme.getIcons': async (): Promise<readonly string[]> => [],
     'MeasureTextHeight.measureTextBlockHeight': async (): Promise<number> => 30,
     'Preferences.get': async (): Promise<any> => false,
   }
   ExtensionHost.registerMockRpc(commandMap)
+  ExtensionManagementWorker.registerMockRpc(commandMap)
   RendererWorker.registerMockRpc(commandMap)
 
   const state: SourceControlState = {
@@ -143,12 +146,13 @@ test('loadContent - with source control actions', async (): Promise<void> => {
     'ExtensionHostSourceControl.getEnabledProviderIds': async (): Promise<readonly string[]> => ['git'],
     'ExtensionHostSourceControl.getGroups': async (): Promise<readonly any[]> => [],
     'ExtensionHostSourceControl.getIconDefinitions': async (): Promise<readonly string[]> => [],
-    'Extensions.getExtensions': async (): Promise<readonly any[]> => mockExtensions,
+    'Extensions.getAllExtensions': async (): Promise<readonly any[]> => mockExtensions,
     'IconTheme.getIcons': async (): Promise<readonly string[]> => [],
     'MeasureTextHeight.measureTextBlockHeight': async (): Promise<number> => 30,
     'Preferences.get': async (): Promise<any> => false,
   }
   ExtensionHost.registerMockRpc(commandMap)
+  ExtensionManagementWorker.registerMockRpc(commandMap)
   RendererWorker.registerMockRpc(commandMap)
 
   const state: SourceControlState = createDefaultState()
@@ -196,12 +200,13 @@ test('loadContent - calculates scroll bar and visible items correctly', async ()
     'ExtensionHostSourceControl.getEnabledProviderIds': async (): Promise<readonly string[]> => ['git'],
     'ExtensionHostSourceControl.getGroups': async (): Promise<readonly any[]> => mockGroups,
     'ExtensionHostSourceControl.getIconDefinitions': async (): Promise<readonly string[]> => [],
-    'Extensions.getExtensions': async (): Promise<readonly any[]> => [],
+    'Extensions.getAllExtensions': async (): Promise<readonly any[]> => [],
     'IconTheme.getIcons': async (): Promise<readonly string[]> => ['icon1', 'icon2'],
     'MeasureTextHeight.measureTextBlockHeight': async (): Promise<number> => 30,
     'Preferences.get': async (): Promise<any> => false,
   }
   ExtensionHost.registerMockRpc(commandMap)
+  ExtensionManagementWorker.registerMockRpc(commandMap)
   RendererWorker.registerMockRpc(commandMap)
 
   const state: SourceControlState = {

--- a/packages/source-control-worker/test/RequestSourceActions.test.ts
+++ b/packages/source-control-worker/test/RequestSourceActions.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@jest/globals'
 import { PlatformType } from '@lvce-editor/constants'
-import { ExtensionHost } from '@lvce-editor/rpc-registry'
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 import { requestSourceActions } from '../src/parts/RequestSourceActions/RequestSourceActions.ts'
 
 test('requestSourceActions', async () => {
@@ -18,19 +18,18 @@ test('requestSourceActions', async () => {
     },
   ]
   const commandMap = {
-    'ExtensionHostSourceControl.requestSourceActions': async (): Promise<typeof mockExtensions> => mockExtensions,
-    'Extensions.getExtensions': async (): Promise<typeof mockExtensions> => mockExtensions,
+    'Extensions.getAllExtensions': async (): Promise<typeof mockExtensions> => mockExtensions,
   }
-  using mockRpc = ExtensionHost.registerMockRpc(commandMap)
+  using mockRpc = ExtensionManagementWorker.registerMockRpc(commandMap)
 
-  const result = await requestSourceActions()
+  const result = await requestSourceActions('/assets', PlatformType.Electron)
 
   expect(result).toEqual({
     action1: 'value1',
     action2: 'value2',
     action3: 'value3',
   })
-  expect(mockRpc.invocations).toEqual([['Extensions.getExtensions']])
+  expect(mockRpc.invocations).toEqual([['Extensions.getAllExtensions', '/assets', PlatformType.Electron]])
 })
 
 test('requestSourceActions excludes extensions that are incompatible with web', async () => {
@@ -45,12 +44,12 @@ test('requestSourceActions excludes extensions that are incompatible with web', 
     },
   ]
   const commandMap = {
-    'Extensions.getExtensions': async (): Promise<typeof mockExtensions> => mockExtensions,
+    'Extensions.getAllExtensions': async (): Promise<typeof mockExtensions> => mockExtensions,
   }
-  using mockRpc = ExtensionHost.registerMockRpc(commandMap)
+  using mockRpc = ExtensionManagementWorker.registerMockRpc(commandMap)
 
-  const result = await requestSourceActions(PlatformType.Web)
+  const result = await requestSourceActions('', PlatformType.Web)
 
   expect(result).toEqual({})
-  expect(mockRpc.invocations).toEqual([['Extensions.getExtensions']])
+  expect(mockRpc.invocations).toEqual([['Extensions.getAllExtensions', '', PlatformType.Web]])
 })

--- a/packages/source-control-worker/test/RequestSourceControlButtons.test.ts
+++ b/packages/source-control-worker/test/RequestSourceControlButtons.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@jest/globals'
 import { PlatformType } from '@lvce-editor/constants'
-import { ExtensionHost } from '@lvce-editor/rpc-registry'
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 import { requestSourceControlButtons } from '../src/parts/RequestSourceControlButtons/RequestSourceControlButtons.ts'
 
 test('requestSourceControlButtons', async () => {
@@ -27,9 +27,9 @@ test('requestSourceControlButtons', async () => {
     },
   ]
   const commandMap = {
-    'Extensions.getExtensions': async (): Promise<typeof mockExtensions> => mockExtensions,
+    'Extensions.getAllExtensions': async (): Promise<typeof mockExtensions> => mockExtensions,
   }
-  using mockRpc = ExtensionHost.registerMockRpc(commandMap)
+  using mockRpc = ExtensionManagementWorker.registerMockRpc(commandMap)
 
   const result = await requestSourceControlButtons()
 
@@ -47,7 +47,7 @@ test('requestSourceControlButtons', async () => {
       label: 'Test',
     },
   ])
-  expect(mockRpc.invocations).toEqual([['Extensions.getExtensions']])
+  expect(mockRpc.invocations).toEqual([['Extensions.getAllExtensions', '', 0]])
 })
 
 test('requestSourceControlButtons excludes extensions that are incompatible with web', async () => {
@@ -67,14 +67,14 @@ test('requestSourceControlButtons excludes extensions that are incompatible with
     },
   ]
   const commandMap = {
-    'Extensions.getExtensions': async (): Promise<typeof mockExtensions> => mockExtensions,
+    'Extensions.getAllExtensions': async (): Promise<typeof mockExtensions> => mockExtensions,
   }
-  using mockRpc = ExtensionHost.registerMockRpc(commandMap)
+  using mockRpc = ExtensionManagementWorker.registerMockRpc(commandMap)
 
-  const result = await requestSourceControlButtons(PlatformType.Web)
+  const result = await requestSourceControlButtons('', PlatformType.Web)
 
   expect(result).toEqual([])
-  expect(mockRpc.invocations).toEqual([['Extensions.getExtensions']])
+  expect(mockRpc.invocations).toEqual([['Extensions.getAllExtensions', '', PlatformType.Web]])
 })
 
 test('requestSourceControlButtons preserves web-incompatible extensions in electron', async () => {
@@ -94,13 +94,13 @@ test('requestSourceControlButtons preserves web-incompatible extensions in elect
     },
   ]
   const commandMap = {
-    'Extensions.getExtensions': async (): Promise<typeof mockExtensions> => mockExtensions,
+    'Extensions.getAllExtensions': async (): Promise<typeof mockExtensions> => mockExtensions,
   }
-  using mockRpc = ExtensionHost.registerMockRpc(commandMap)
+  using mockRpc = ExtensionManagementWorker.registerMockRpc(commandMap)
 
-  const result = await requestSourceControlButtons(PlatformType.Electron)
+  const result = await requestSourceControlButtons('', PlatformType.Electron)
 
   expect(result).toHaveLength(1)
   expect(result[0].label).toBe('Commit & Sync')
-  expect(mockRpc.invocations).toEqual([['Extensions.getExtensions']])
+  expect(mockRpc.invocations).toEqual([['Extensions.getAllExtensions', '', PlatformType.Electron]])
 })


### PR DESCRIPTION
Fix source control metadata loading by using the dedicated extension-management RPC and the supported Extensions.getAllExtensions command. Forward the asset and platform context, and update regression coverage for the corrected command path.